### PR TITLE
Fix projects using company URL instead of project

### DIFF
--- a/_layouts/about-me.html
+++ b/_layouts/about-me.html
@@ -124,7 +124,7 @@ layout: default
                             <h4 class="experience-title"> {{ project.project_title }}</h4>
                             <h6 class="experience-info"> {{ project.project_info}}</h6>
                             <p class="experience-desc"> {{ project.project_description }} </p>
-                            <p><a class="project-link" href="{{exp.company_url}}">{{ project.project_url}}</a></p>
+                            <p><a class="project-link" href="{{project.project_url}}">{{ project.project_url}}</a></p>
                         </div>
                     </div>
                     {% endif %}


### PR DESCRIPTION
Hi, I noticed the project URL are instead going to company. This pull request fixes the issue.