### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ devlopr uses Markdown Files to create data like Blog Posts, Gallery, Shop Produc
 - Supports Latest [Jekyll 4.x](https://jekyllrb.com) and [Bundler](https://bundler.io)
 - Stylesheet built using Sass
 - Comments using [Hyvor](https://talk.hyvor.com/) and [Disqus](https://disqus.com/)
-- Google SEO and Analytics Optimized
+- SEO-optimized
 - Real Time Search using [Algolia](https://algolia.com/)
 - Sell Stuff (Ecommerce) in your Blog using [Snipcart](https://snipcart.com/)
 - Send Newsletters using [Mailchimp](https://mailchimp.com/)

--- a/_config.yml
+++ b/_config.yml
@@ -97,9 +97,6 @@ markdown: kramdown
 highlighter: rouge
 permalink: pretty
 
-# google analytics
-google_analytics: UA-46783401-10
-
 # Choose what to show ( can be true or false)
 show_author_work_experiences: true
 show_author_education_details: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -180,33 +180,4 @@
     data-x_margin="10"
     data-y_margin="10"
   ></script>
-
-  {% if jekyll.environment == "production" %}
-
-  <script>
-    (function(i, s, o, g, r, a, m) {
-      i["GoogleAnalyticsObject"] = r;
-      (i[r] =
-        i[r] ||
-        function() {
-          (i[r].q = i[r].q || []).push(arguments);
-        }),
-        (i[r].l = 1 * new Date());
-      (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-      a.async = 1;
-      a.src = g;
-      m.parentNode.insertBefore(a, m);
-    })(
-      window,
-      document,
-      "script",
-      "https://www.google-analytics.com/analytics.js",
-      "ga"
-    );
-
-    ga("create", "{{ site.google_analytics }}", "auto");
-    ga("send", "pageview");
-  </script>
-
-  {% endif %}
 </head>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/