### PR TITLE
minor typo

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -35,7 +35,7 @@ layout: default
                 <li class="pagination-link disabled"><span aria-hidden="true">&laquo;</span></li>
               {% endif %}
 
-              <li class="pagination-link ><a href="/blog">First</a></li>
+              <li class="pagination-link" ><a href="/blog">First</a></li>
 
               {% for page in (1..paginator.total_pages) %}
                 {% if page == paginator.page %}


### PR DESCRIPTION
Removed a minor typo which was causing the `First` link in the pagination of the `blog` page to not work