### PR TITLE
Fix asset path with baseurl

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -73,7 +73,7 @@
   {% endif %}
 
   <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/assets/css/main.css" />
-  <!-- <link rel="stylesheet" href="/assets/css/custom-style.css" /> -->
+  <!-- <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/assets/css/custom-style.css" /> -->
   <link
     rel="stylesheet"
     href="{{site.url}}{{site.baseurl}}/assets/bower_components/lightgallery/dist/css/lightgallery.min.css"
@@ -116,7 +116,7 @@
     integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh"
     crossorigin="anonymous"
   ></script>
-  <!-- <script src="/assets/bower_components/jquery/dist/jquery.min.js"></script> -->
+  <!-- <script src="{{site.url}}{{site.baseurl}}/assets/bower_components/jquery/dist/jquery.min.js"></script> -->
   <script src="{{site.url}}{{site.baseurl}}/assets/bower_components/jquery.easing/jquery.easing.min.js"></script>
   <script src="{{site.url}}{{site.baseurl}}/assets/bower_components/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{site.url}}{{site.baseurl}}/assets/bower_components/jquery-mousewheel/jquery.mousewheel.min.js"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,7 +10,7 @@ layout: default
   });
 </script>
     <div class="jumbotron" style="text-align: center;">
-      <img class="author-profile-img" src="/assets/img/profile.png" />
+      <img class="author-profile-img" src="{{site.url}}{{site.baseurl}}/assets/img/profile.png" />
       <p class="jumbotron-heading">Hi, I am {{site.author}} !</p>
       <p class="lead" id="typewriteText"></p>
          {%- include github_star_button.html -%}
@@ -35,7 +35,7 @@ layout: default
               <div id="article-container">
                 <div id="article-img">
                   <img
-                    src="/assets/img/{{site.author_logo}}"
+                    src="{{site.url}}{{site.baseurl}}/assets/img/{{site.author_logo}}"
                     width="50px"
                     height="50px"
                   />


### PR DESCRIPTION
Fixes a problem similar to that explained in https://github.com/sujaykundu777/devlopr-jekyll/issues/31, which was fixed earlier but happened again: when using devlopr with a non-empty baseurl some assets did not load because they where declared in the code without the baseurl  (e.g. the author logo in the home)