### PR TITLE
Fix navbar-brand with baseurl

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
           >
             <span class="icono-hamburger" id="navbar-hamburger"> </span>
           </button>
-          <a class="navbar-brand" href="/">{{site.title}}</a>
+          <a class="navbar-brand" href="{{site.url}}{{site.baseurl}}">{{site.title}}</a>
           <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
               {% for i in site.urls %}


### PR DESCRIPTION
`.navbar-brand`, the element in the top left with the `site.title`, when clicked did not respect the `baseurl` configuration. This is fixed in this pull request