### PR TITLE
fixed pagination page number formatting issue

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -39,7 +39,7 @@ layout: default
 
               {% for page in (1..paginator.total_pages) %}
                 {% if page == paginator.page %}
-                  <li class="active pagination-link"><a>{{ page }}<span class="sr-only">(current)</span></a></li>
+             <li class="disabled pagination-link"><span><b>{{ page }}</b></span></li>
                 {% elsif page == 1 %}
                   <li class="pagination-link"><a href="/blog">{{ page }}</a></li>
                 {% else %}


### PR DESCRIPTION
Previously, the page number for the current page would appear as if it were an active link, so it was difficult for the user to tell which page they were currently viewing. Here's how it used to look when the user was viewing Page 1:
![image](https://user-images.githubusercontent.com/37491308/212785121-6e73bae9-2cea-4aac-aca1-1d29cc4d363f.png)

Now, the page number for the current page appears as standard bold text, which is a common design pattern in many other pagination implementations. Here's how it looks now when the user is viewing Page 1:
![image](https://user-images.githubusercontent.com/37491308/212785164-6d5c95ae-66a4-4dab-b496-c1f1a28434da.png)
