### PR TITLE
fix: img was overflow screen

### DIFF
--- a/_sass/devlopr.scss
+++ b/_sass/devlopr.scss
@@ -109,6 +109,10 @@ ol, ul {
     margin-left: 30px !important;
 }
 
+img {
+    max-width: 100%;
+}
+
 /* Progress bar */
 .progressline .bar {
     background: #f69801;

--- a/_sass/devlopr.scss
+++ b/_sass/devlopr.scss
@@ -109,10 +109,6 @@ ol, ul {
     margin-left: 30px !important;
 }
 
-img {
-    max-width: 100%;
-}
-
 /* Progress bar */
 .progressline .bar {
     background: #f69801;
@@ -432,6 +428,10 @@ header {
 #blog-post-container{
     margin-top: 20px;
     margin-left: -35px;
+
+    img {
+        max-width: 100%;
+    }
 }
 
 .snipcart-modal__container {


### PR DESCRIPTION
In the post page, when the image too big, overflow than the screen, it comes cross the page horizontally as example below

![image](https://github.com/sujaykundu777/devlopr-jekyll/assets/28798624/6c5ceb7f-f470-482f-ad7f-4be4b8e4ada8)

This PR was fixed to set the `max-width` of image just 100%, after fixing:

![image](https://github.com/sujaykundu777/devlopr-jekyll/assets/28798624/e9e5099b-0e70-4f37-8e2e-59cede8cde19)
