### PR TITLE
Fixed the ending of m1 mac shell script that overrides system ruby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Edit either the  ~/.zshrc and ~/.zprofile files:
 if [ -d "/opt/homebrew/opt/ruby/bin" ]; then
   export PATH=/opt/homebrew/opt/ruby/bin:$PATH
   export PATH=`gem environment gemdir`/bin:$PATH
+fi
 ```
 
 ### For Mac Intel 


### PR DESCRIPTION
without the fix below error thrown as expected:
zshrc:109: parse error near `\n'